### PR TITLE
.env移行とbluesky/twitterの有効化オプションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@
 3. .envの中身
 
 ```env
-TW_API_KEY = "TwitterのAPI_KEY"
-TW_API_KEY_SECRET = "TwitterのAPI_KEY_SECRET"
-TW_ACCESS_TOKEN = "TwitterのACCESS_TOKEN"
-TW_ACCESS_TOKEN_SECRET = "TwitterのACCESS_TOKEN_SECRET"
-BS_IDENTIFIER = "BlueskyのIDENTIFIER"
-BS_APP_PASSWORD = "BlueskyのAPP_PASSWORD"
-BS_SERVICE = "BlueskyのサーバーURL https://bsky.social　とか"
-CC_SUBKEY = "コンカレのサブキー"
+TW_ENABLE="true" or "false"
+TW_API_KEY="TwitterのAPI_KEY"
+TW_API_KEY_SECRET="TwitterのAPI_KEY_SECRET"
+TW_ACCESS_TOKEN="TwitterのACCESS_TOKEN"
+TW_ACCESS_TOKEN_SECRET="TwitterのACCESS_TOKEN_SECRET"
+BS_ENABLE="true" or "false"
+BS_IDENTIFIER="BlueskyのIDENTIFIER"
+BS_APP_PASSWORD="BlueskyのAPP_PASSWORD"
+BS_SERVICE="BlueskyのサーバーURL https://bsky.social　とか"
+CC_SUBKEY="コンカレのサブキー"
 ```
 4. `npm start`で多分動く！！
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@
 
 ## Setup
 1. `npm i`
-2. `env.js`を作成する
-3. env.jsの中身
-``` javascript
-exports.TW_API_KEY = "TwitterのAPI_KEY"
-exports.TW_API_KEY_SECRET = "TwitterのAPI_KEY_SECRET"
-exports.TW_ACCESS_TOKEN = "TwitterのACCESS_TOKEN"
-exports.TW_ACCESS_TOKEN_SECRET = "TwitterのACCESS_TOKEN_SECRET"
-exports.BS_IDENTIFIR = "BlueskyのIDENTIFIR"
-exports.BS_APP_PASSWORD = "BlueskyのAPP_PASSWORD"
-exports.BS_SERVICE = "BlueskyのサーバーURL https://bsky.social　とか"
-exports.CC_SUBKEY = "コンカレのサブキー"
+2. `.env`を作成する
+3. .envの中身
+
+```env
+TW_API_KEY = "TwitterのAPI_KEY"
+TW_API_KEY_SECRET = "TwitterのAPI_KEY_SECRET"
+TW_ACCESS_TOKEN = "TwitterのACCESS_TOKEN"
+TW_ACCESS_TOKEN_SECRET = "TwitterのACCESS_TOKEN_SECRET"
+BS_IDENTIFIER = "BlueskyのIDENTIFIER"
+BS_APP_PASSWORD = "BlueskyのAPP_PASSWORD"
+BS_SERVICE = "BlueskyのサーバーURL https://bsky.social　とか"
+CC_SUBKEY = "コンカレのサブキー"
 ```
-4. `node concrnt2SNS.js`で多分動く！！
+4. `npm start`で多分動く！！
 
 ## その他
 foreverとかでデーモン化するといいかも  

--- a/concrnt2SNS.js
+++ b/concrnt2SNS.js
@@ -6,19 +6,21 @@ const CCMsgAnalysis = require('./ConcrntMessageAnalysis.js')
 
 const CC_SUBKEY = process.env.CC_SUBKEY
 
+const TW_ENABLE = process.env.TW_ENABLE == "true"
 const TW_API_KEY = process.env.TW_API_KEY
 const TW_API_KEY_SECRET = process.env.TW_API_KEY_SECRET
 
 const TW_ACCESS_TOKEN = process.env.TW_ACCESS_TOKEN
 const TW_ACCESS_TOKEN_SECRET = process.env.TW_ACCESS_TOKEN_SECRET
 
+const BS_ENABLE = process.env.BS_ENABLE == "true"
 const BS_IDENTIFIER = process.env.BS_IDENTIFIER
 const BS_APP_PASSWORD = process.env.BS_APP_PASSWORD
 const BS_SERVICE = process.env.BS_SERVICE
 
 const image = new ImageResize()
-const twitterClient = new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET)
-const bskyClient = new AtProtocol(BS_SERVICE, BS_IDENTIFIER, BS_APP_PASSWORD)
+const twitterClient = TW_ENABLE && new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET)
+const bskyClient = BS_ENABLE && new AtProtocol(BS_SERVICE, BS_IDENTIFIER, BS_APP_PASSWORD)
 const ccMsgAnalysis = new CCMsgAnalysis()
 
 async function start() {
@@ -45,8 +47,8 @@ function receivedPost(data) {
 
         if (text.length > 0 || files.length > 0) {
             image.downloader(files).then(filesBuffer => {
-                twitterClient.tweet(text, filesBuffer)
-                bskyClient.post(text, filesBuffer)
+                if (TW_ENABLE) twitterClient.tweet(text, filesBuffer)
+                if (BS_ENABLE) bskyClient.post(text, filesBuffer)
             })
         }
     }

--- a/concrnt2SNS.js
+++ b/concrnt2SNS.js
@@ -1,25 +1,24 @@
 const cc = require('@concurrent-world/client')
-const env = require('./env.js')
 const ImageResize = require('./Image.js')
 const Twitter = require('./Twitter.js')
 const AtProtocol = require('./AtProtocol.js')
 const CCMsgAnalysis = require('./ConcrntMessageAnalysis.js')
 
-const CC_SUBKEY = env.CC_SUBKEY
+const CC_SUBKEY = process.env.CC_SUBKEY
 
-const TW_API_KEY = env.TW_API_KEY
-const TW_API_KEY_SECRET = env.TW_API_KEY_SECRET
+const TW_API_KEY = process.env.TW_API_KEY
+const TW_API_KEY_SECRET = process.env.TW_API_KEY_SECRET
 
-const TW_ACCESS_TOKEN = env.TW_ACCESS_TOKEN
-const TW_ACCESS_TOKEN_SECRET = env.TW_ACCESS_TOKEN_SECRET
+const TW_ACCESS_TOKEN = process.env.TW_ACCESS_TOKEN
+const TW_ACCESS_TOKEN_SECRET = process.env.TW_ACCESS_TOKEN_SECRET
 
-const BS_IDENTIFIR = env.BS_IDENTIFIR
-const BS_APP_PASSWORD = env.BS_APP_PASSWORD
-const BS_SERVICE = env.BS_SERVICE
+const BS_IDENTIFIER = process.env.BS_IDENTIFIER
+const BS_APP_PASSWORD = process.env.BS_APP_PASSWORD
+const BS_SERVICE = process.env.BS_SERVICE
 
 const image = new ImageResize()
 const twitterClient = new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET)
-const bskyClient = new AtProtocol(BS_SERVICE, BS_IDENTIFIR, BS_APP_PASSWORD)
+const bskyClient = new AtProtocol(BS_SERVICE, BS_IDENTIFIER, BS_APP_PASSWORD)
 const ccMsgAnalysis = new CCMsgAnalysis()
 
 async function start() {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+      "start": "node --env-file=.env concrnt2SNS.js"
+  },
   "dependencies": {
     "@atproto/api": "^0.12.21",
     "@concurrent-world/client": "^6.0.17",


### PR DESCRIPTION
## 変更した点
- 設定がenv.jsにより与えられていた点をprocess.envにより環境変数を直接読み込むように変更 & nodeのデフォルト機能での.envファイルの読み込みを利用するようにしました

これはコンテナ等に押し込んだ時に、直接生の環境変数を利用した方が都合が良いためこうしてみました！

- Twitter/Blueskyそれぞれの転送の有効/無効のオプションを追加

これは単純に僕がBlueskyのみ利用したかったからですね...

## その他
多分大丈夫だとは思うんですが、twitterを有効にしたうえでの動作確認はやってないです 🙇  Blueskyのみ設定時は動作確認OKでした！ 🙆‍♂️ 


no issueでのPRなので方針等違いあれば修正 or そのままCloseでも大丈夫です 🙇 