### PR TITLE
メディアなしのTweetをIFTTT経由で行えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BS_SERVICE="BlueskyのサーバーURL https://bsky.social　とか"
 CC_SUBKEY="コンカレのサブキー"
 LISTEN_TIMELINE="ホーム以外のタイムラインを指定したい場合はID@host形式で1つ指定"
 
-// Option
+// Option（使わない場合は入れないこと）
 TW_WEBHOOK_URL="メディアなしのTweetをIFTTT経由で行う場合のWebHookURL"
 ```
 4. `npm start`で多分動く！！
@@ -28,3 +28,10 @@ TW_WEBHOOK_URL="メディアなしのTweetをIFTTT経由で行う場合のWebHoo
 ## その他
 pm2とかでデーモン化するといいかも  
 https://pm2.keymetrics.io/  
+
+## TW_WEBHOOK_URLについて
+Twitterの無料APIの制限がキツイので、メディアなしのTweetをIFTTT経由で行えるようにしました。  
+IFTTTでこいういうAppletを作ってWebHookのURLをTW_WEBHOOK_URLにセットしてください。  
+![image](https://github.com/user-attachments/assets/6350bd08-b941-4108-8b13-fda947bdd655)
+![image](https://github.com/user-attachments/assets/3c4b34ca-4412-458a-9342-d0b537f7cc6e)
+

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ BS_APP_PASSWORD="BlueskyのAPP_PASSWORD"
 BS_SERVICE="BlueskyのサーバーURL https://bsky.social　とか"
 CC_SUBKEY="コンカレのサブキー"
 LISTEN_TIMELINE="ホーム以外のタイムラインを指定したい場合はID@host形式で1つ指定"
+
+// Option
+TW_WEBHOOK_URL="メディアなしのTweetをIFTTT経由で行う場合のWebHookURL"
 ```
 4. `npm start`で多分動く！！
 
 ## その他
-foreverとかでデーモン化するといいかも  
-https://www.npmjs.com/package/forever
+pm2とかでデーモン化するといいかも  
+https://pm2.keymetrics.io/  

--- a/Twitter.js
+++ b/Twitter.js
@@ -1,27 +1,48 @@
 const twV2 = require('twitter-api-v2')
+const axios = require('axios')
 
 class Twitter {
-    constructor(apiKey, apiKeySecret, token, tokenSecret) {
+    constructor(apiKey, apiKeySecret, token, tokenSecret, webhookURL) {
         this.twitterClient = new twV2.TwitterApi({
             appKey: apiKey,
             appSecret: apiKeySecret,
             accessToken: token,
             accessSecret: tokenSecret,
         })
+
+        this.webhookURL = webhookURL
     }
 
     async tweet(text, filesBuffer) {
         const mediaIds = await this.uploadMedia(filesBuffer)
-    
+
         if (mediaIds.length > 0) {
             await this.twitterClient.v2.tweet({
                 text: text,
                 media: { media_ids: mediaIds }
             })
         } else {
-            await this.twitterClient.v2.tweet({
-                text: text
-            })
+            if (this.webhookURL != undefined) {
+                let config = {
+                    method: 'post',
+                    url: this.webhookURL,
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    data: {"value1": text}
+                }
+
+                try {
+                    await axios(config)
+                } catch (error) {
+                    const responseStatus = error.response.status
+                    console.log(`Failed to tweet on WebHook. code:${responseStatus}`)
+                }
+            } else {
+                await this.twitterClient.v2.tweet({
+                    text: text
+                })
+            }
         }
     }
 

--- a/concrnt2SNS.js
+++ b/concrnt2SNS.js
@@ -9,9 +9,9 @@ const CC_SUBKEY = process.env.CC_SUBKEY
 const TW_ENABLE = process.env.TW_ENABLE == "true"
 const TW_API_KEY = process.env.TW_API_KEY
 const TW_API_KEY_SECRET = process.env.TW_API_KEY_SECRET
-
 const TW_ACCESS_TOKEN = process.env.TW_ACCESS_TOKEN
 const TW_ACCESS_TOKEN_SECRET = process.env.TW_ACCESS_TOKEN_SECRET
+const TW_WEBHOOK_URL = process.env.TW_WEBHOOK_URL
 
 const BS_ENABLE = process.env.BS_ENABLE == "true"
 const BS_IDENTIFIER = process.env.BS_IDENTIFIER
@@ -21,7 +21,7 @@ const BS_SERVICE = process.env.BS_SERVICE
 const LISTEN_TIMELINE = process.env.LISTEN_TIMELINE
 
 const image = new ImageResize()
-const twitterClient = TW_ENABLE && new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET)
+const twitterClient = TW_ENABLE && new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET, TW_WEBHOOK_URL)
 const bskyClient = BS_ENABLE && new AtProtocol(BS_SERVICE, BS_IDENTIFIER, BS_APP_PASSWORD)
 const ccMsgAnalysis = new CCMsgAnalysis()
 


### PR DESCRIPTION
Twitterの無料APIの制限がキツイので、とりあえずメディアなしのTweetをIFTTT経由で行えるようにしました。
詳細はREADME読んでね。