### PR TITLE
Loggerクラスを追加し、コンソールメソッドをオーバーライドする機能を実装

### DIFF
--- a/src/Clients/AtProtocol.js
+++ b/src/Clients/AtProtocol.js
@@ -28,7 +28,9 @@ class AtProtocol {
             password: appPassword
         })
 
-        console.log(`BS Login : ${loginResult}`)
+        const safeLoginResult = { ...loginResult, data: { ...loginResult.data, accessJwt: '***' } }
+        console.log(`BS Login : ${JSON.stringify(safeLoginResult)}`)
+        //console.log(`BS Login : ${JSON.stringify(loginResult)}`)
         // audの取得
         // あんまりイケてないカモ・・・
         const jwt = loginResult.data.accessJwt.split(".").map((jwt) => {

--- a/src/Clients/Threads.js
+++ b/src/Clients/Threads.js
@@ -25,10 +25,10 @@ class Threads {
         const tokenInfo = await Threads.getTokenInfo(token);
         const userId = tokenInfo.user_id;
         if (tokenInfo.is_valid === false) {
-            console.error('無効なアクセストークンです。Threadsクライアントの作成に失敗しました。');
+            console.error('無効なアクセストークンです。Threadsクライアントの作成に失敗しました。', true);
             return false;
         } else if (userId == null) {
-            console.error('アクセストークンからユーザーIDを取得できませんでした。Threadsクライアントの作成に失敗しました。');
+            console.error('ユーザーIDを取得できませんでした。Threadsクライアントの作成に失敗しました。', true);
             return false;
         }
 
@@ -62,7 +62,7 @@ class Threads {
             console.log('アクセストークン情報:', response.data.data);
             return response.data.data;
         } catch (error) {
-            console.error('アクセストークンの情報取得に失敗しました:', error.message);
+            console.error('アクセストークンの情報取得に失敗しました:', true, error.message);
             return { is_valid: false };
         }
     }
@@ -83,7 +83,7 @@ class Threads {
                 "expires_at": Date.now() + (response.data.expires_in * 1000)
             };
         } catch (error) {
-            console.error('アクセストークンの更新に失敗しました:', error.message);
+            console.error('アクセストークンの更新に失敗しました:', true, error.message);
             return undefined;
         }
     }

--- a/src/Utils/Logger.js
+++ b/src/Utils/Logger.js
@@ -1,0 +1,115 @@
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+const DISCORD_MENTION_ID = process.env.DISCORD_MENTION_ID;
+
+class Logger {
+	constructor(options = {}) {
+		this.level = options.level || 'info';
+		this.label = options.label || null;
+	}
+
+	static getInstance(options = {}) {
+		if (!Logger._instance) {
+			Logger._instance = new Logger(options);
+		} else {
+			if (options.level) Logger._instance.setLevel(options.level);
+			if (options.label) Logger._instance.setLabel(options.label);
+		}
+		return Logger._instance;
+	}
+
+	/**
+	 * Replace global console methods with Logger-backed implementations.
+	 * Saves originals on `globalThis.__originalConsole` so restoreConsole() can revert.
+	 */
+	static overrideConsole(options = {}) {
+		if (globalThis.__originalConsole) return; // already overridden
+		globalThis.__originalConsole = {
+			log: console.log,
+			info: console.info,
+			warn: console.warn,
+			error: console.error,
+			debug: console.debug,
+		};
+
+		const logger = Logger.getInstance(options);
+
+		console.log = (...args) => {
+			const [first, ...rest] = args;
+			let isMention = false;
+			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
+			logger.info(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+		};
+		console.info = (...args) => {
+			const [first, ...rest] = args;
+			let isMention = false;
+			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
+			logger.info(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+		};
+		console.warn = (...args) => {
+			const [first, ...rest] = args;
+			let isMention = false;
+			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
+			logger.warn(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+		};
+		console.error = (...args) => {
+			const [first, ...rest] = args;
+			let isMention = false;
+			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
+			logger.error(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+		};
+		console.debug = (...args) => {
+			const [first, ...rest] = args;
+			let isMention = false;
+			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
+			logger.debug(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+		};
+	}
+
+	/** Restore original global console methods saved by overrideConsole(). */
+	static restoreConsole() {
+		if (!globalThis.__originalConsole) return;
+		const orig = globalThis.__originalConsole;
+		console.log = orig.log;
+		console.info = orig.info;
+		console.warn = orig.warn;
+		console.error = orig.error;
+		console.debug = orig.debug;
+		delete globalThis.__originalConsole;
+	}
+
+	shouldLog(level) {
+		return LEVELS[level] >= LEVELS[this.level];
+	}
+
+	format(level, msg, isMention = false) {
+		const ts = new Date().toISOString();
+		const lbl = this.label ? `[${this.label}] ` : '';
+		const body = typeof msg === 'string' ? msg : JSON.stringify(msg);
+		const hasMentionId = typeof DISCORD_MENTION_ID !== 'undefined' && DISCORD_MENTION_ID !== null && String(DISCORD_MENTION_ID).trim() !== '';
+		const mention = isMention && hasMentionId ? `<@${DISCORD_MENTION_ID}> ` : '';
+		return `${mention}${ts} ${level.toUpperCase()}: ${lbl}${body}`;
+	}
+
+	log(level, msg, isMention = false, ...meta) {
+		if (!LEVELS.hasOwnProperty(level)) level = 'info';
+		if (!this.shouldLog(level)) return;
+		const formatted = this.format(level, msg, isMention);
+		// Use original console methods when available to avoid recursion
+		const origConsole = (globalThis && globalThis.__originalConsole) ? globalThis.__originalConsole : console;
+		if (level === 'error') origConsole.error(formatted, ...meta);
+		else if (level === 'warn') origConsole.warn(formatted, ...meta);
+		else if (level === 'debug') (origConsole.debug || origConsole.log)(formatted, ...meta);
+		else origConsole.info(formatted, ...meta);
+	}
+
+	debug(msg,isMention = false,...meta) { this.log('debug', msg, isMention, ...meta); }
+	info(msg, isMention = false, ...meta) { this.log('info', msg, isMention, ...meta); }
+	warn(msg, isMention = false, ...meta) { this.log('warn', msg, isMention, ...meta); }
+	error(msg, isMention = false, ...meta) { this.log('error', msg, isMention, ...meta); }
+
+	setLevel(level) { if (LEVELS[level] !== undefined) this.level = level; }
+	setLabel(label) { this.label = label; }
+}
+
+export default Logger;
+

--- a/src/Utils/Logger.js
+++ b/src/Utils/Logger.js
@@ -1,5 +1,23 @@
+import { format as utilFormat } from 'node:util';
+
 const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 const DISCORD_MENTION_ID = process.env.DISCORD_MENTION_ID;
+
+/**
+ * Safely format arbitrary values into a human-readable string.
+ * - Error objects: uses stack (includes message) or falls back to message/String()
+ * - Other values: uses util.format (handles circular refs, objects, primitives)
+ */
+function safeFormat(...args) {
+	try {
+		return utilFormat(...args);
+	} catch {
+		return args.map(a => {
+			if (a instanceof Error) return a.stack || a.message || String(a);
+			try { return JSON.stringify(a); } catch { return String(a); }
+		}).join(' ');
+	}
+}
 
 class Logger {
 	constructor(options = {}) {
@@ -37,31 +55,31 @@ class Logger {
 			const [first, ...rest] = args;
 			let isMention = false;
 			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
-			logger.info(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+			logger.info(safeFormat(first, ...rest), isMention);
 		};
 		console.info = (...args) => {
 			const [first, ...rest] = args;
 			let isMention = false;
 			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
-			logger.info(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+			logger.info(safeFormat(first, ...rest), isMention);
 		};
 		console.warn = (...args) => {
 			const [first, ...rest] = args;
 			let isMention = false;
 			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
-			logger.warn(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+			logger.warn(safeFormat(first, ...rest), isMention);
 		};
 		console.error = (...args) => {
 			const [first, ...rest] = args;
 			let isMention = false;
 			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
-			logger.error(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+			logger.error(safeFormat(first, ...rest), isMention);
 		};
 		console.debug = (...args) => {
 			const [first, ...rest] = args;
 			let isMention = false;
 			if (rest.length && typeof rest[0] === 'boolean') isMention = rest.shift();
-			logger.debug(typeof first === 'string' ? first : JSON.stringify(first), isMention, ...rest);
+			logger.debug(safeFormat(first, ...rest), isMention);
 		};
 	}
 
@@ -84,7 +102,7 @@ class Logger {
 	format(level, msg, isMention = false) {
 		const ts = new Date().toISOString();
 		const lbl = this.label ? `[${this.label}] ` : '';
-		const body = typeof msg === 'string' ? msg : JSON.stringify(msg);
+		const body = typeof msg === 'string' ? msg : safeFormat(msg);
 		const hasMentionId = typeof DISCORD_MENTION_ID !== 'undefined' && DISCORD_MENTION_ID !== null && String(DISCORD_MENTION_ID).trim() !== '';
 		const mention = isMention && hasMentionId ? `<@${DISCORD_MENTION_ID}> ` : '';
 		return `${mention}${ts} ${level.toUpperCase()}: ${lbl}${body}`;

--- a/src/concrnt2SNS.js
+++ b/src/concrnt2SNS.js
@@ -5,6 +5,9 @@ import AtProtocol from './Clients/AtProtocol.js'
 import Threads from './Clients/Threads.js'
 import Nostr from './Clients/Nostr.js'
 import CCMsgAnalysis from './Utils/ConcrntMessageAnalysis.js'
+import Logger from './Utils/Logger.js'
+
+Logger.overrideConsole({ level: 'info', label: 'concrnt2SNS' })
 
 const CC_SUBKEY = process.env.CC_SUBKEY
 


### PR DESCRIPTION
- [x] `node:util` の `format` を使った `safeFormat` ヘルパーを追加し、Errorオブジェクトや循環参照を安全に処理
- [x] `overrideConsole()` の各コンソールメソッド (lines 54-83) で `JSON.stringify(first)` を `safeFormat(first, ...rest)` に置き換え
- [x] `format()` メソッド (line 105) の `JSON.stringify(msg)` を `safeFormat(msg)` に置き換え
- [x] 変更を検証・テスト (全6テストケースパス)