### PR TITLE
fix: loginメソッドでのJWTを安全にログ出力するように修正

### DIFF
--- a/src/Clients/AtProtocol.js
+++ b/src/Clients/AtProtocol.js
@@ -28,9 +28,9 @@ class AtProtocol {
             password: appPassword
         })
 
-        const safeLoginResult = { ...loginResult, data: { ...loginResult.data, accessJwt: '***' } }
-        console.log(`BS Login : ${JSON.stringify(safeLoginResult)}`)
-        //console.log(`BS Login : ${JSON.stringify(loginResult)}`)
+        const safeLoginResult = { ...loginResult, data: { ...loginResult.data, accessJwt: '***', refreshJwt: '***' } }
+        console.log(`BS Login : ${JSON.stringify(safeLoginResult, null, 2)}`)
+        //console.log(`BS Login : ${JSON.stringify(loginResult, null, 2)}`)
         // audの取得
         // あんまりイケてないカモ・・・
         const jwt = loginResult.data.accessJwt.split(".").map((jwt) => {


### PR DESCRIPTION
This pull request makes a small but important update to how login results are logged in the `AtProtocol` class. The change ensures that both `accessJwt` and `refreshJwt` fields are masked in the logs, and also improves the readability of the logged JSON output.

- Security and logging improvements:
  * Updated the `safeLoginResult` object in `AtProtocol.js` to mask both `accessJwt` and `refreshJwt` fields before logging, and formatted the JSON output for better readability.
<!-- I want to review in Japanese. -->
コードレビューは日本語ですること。
指示がない限り新規でPRを作ってはいけません。
PRを作成する場合は、概要やコメントは日本語で書くこと。
<!-- I want to review in Japanese. -->
