### PR TITLE
fix: Concrntクライアントの作成失敗時にエラーメッセージを出力し、プロセスを終了するように修正

### DIFF
--- a/src/concrnt2SNS.js
+++ b/src/concrnt2SNS.js
@@ -39,6 +39,10 @@ const LISTEN_TIMELINE = process.env.LISTEN_TIMELINE
 
 const media = new Media()
 const ccClient = await Client.createFromSubkey(CC_SUBKEY)
+if (!ccClient) {
+    console.error("Failed to create Concrnt client.")
+    process.exit(1)
+}
 const twitterClient = TW_ENABLE && new Twitter(TW_API_KEY, TW_API_KEY_SECRET, TW_ACCESS_TOKEN, TW_ACCESS_TOKEN_SECRET, TW_WEBHOOK_URL, TW_WEBHOOK_IMAGE_URL)
 const bskyClient = BS_ENABLE && await AtProtocol.build(BS_SERVICE, BS_IDENTIFIER, BS_APP_PASSWORD)
 const threadsClient = THREADS_ENABLE && await Threads.create(THREADS_ACCESS_TOKEN)


### PR DESCRIPTION
This pull request adds a safety check to ensure that the `ccClient` is successfully created before proceeding. If client creation fails, the application will log an error and exit. This helps prevent downstream errors caused by an uninitialized client.

- Error handling improvement:
  * Added a check after attempting to create `ccClient` with `Client.createFromSubkey()`. If client creation fails, an error is logged and the process exits to prevent further execution with an invalid client.

<!-- I want to review in Japanese. -->
コードレビューは日本語ですること。
指示がない限り新規でPRを作ってはいけません。
PRを作成する場合は、概要やコメントは日本語で書くこと。
<!-- I want to review in Japanese. -->
