### PR TITLE
Refactor: Replace axios with native fetch API

### DIFF
--- a/docs/Clients/AtProtocol.md
+++ b/docs/Clients/AtProtocol.md
@@ -249,7 +249,7 @@ record.facets = rt.facets;
 ## 依存関係
 
 - `@atproto/api` - AT Protocol クライアント
-- `axios` - HTTP リクエスト（動画アップロード用）
+- `fetch API` - HTTP リクエスト（動画アップロード用）
 - `OgImage` - OGP画像取得
 
 ## 使用例

--- a/docs/Clients/Threads.md
+++ b/docs/Clients/Threads.md
@@ -257,7 +257,7 @@ static BASE_URL = `https://graph.threads.net/${Threads.graphApiVersion}/`;
 
 ## 依存関係
 
-- `axios` - HTTP リクエスト
+- `fetch API` - HTTP リクエスト
 - `fs/promises` - ファイル読み書き（トークン保存）
 
 ## 使用例

--- a/docs/Clients/Twitter.md
+++ b/docs/Clients/Twitter.md
@@ -180,7 +180,7 @@ await twitterClient.tweet('画像付きツイート', filesBuffer);
 ## 依存関係
 
 - `twitter-api-v2` - Twitter API v2 クライアント
-- `axios` - HTTP リクエスト（WebHook用）
+- `fetch API` - HTTP リクエスト（WebHook用）
 
 ## 使用例
 

--- a/docs/Utils/MetaTagExtractor.md
+++ b/docs/Utils/MetaTagExtractor.md
@@ -3,7 +3,7 @@
 ## 概要
 
 `MetaTagExtractor`は、`open-graph-scraper`の制限を克服するために作成された、より堅牢なメタ情報抽出クラスです。
-axios と cheerio を使用して、任意のWebページからメタデータを抽出します。
+fetch API と cheerio を使用して、任意のWebページからメタデータを抽出します。
 
 ## 機能
 
@@ -77,7 +77,7 @@ const metaWithOptions = await extractor.extractMeta('https://example.com', {
 
 ## 依存関係
 
-- `axios` - HTTP リクエスト
+- `fetch API` - HTTP リクエスト
 - `cheerio` - HTML パース（新規追加）
 
 ## 注意事項

--- a/docs/Utils/OgImage.md
+++ b/docs/Utils/OgImage.md
@@ -148,7 +148,7 @@ const GOOGLE_FAVICON_URL = "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=
 ## 依存関係
 
 - `sharp` - 画像処理
-- `axios` - HTTP リクエスト
+- `fetch API` - HTTP リクエスト
 - `MetaTagExtractor` - メタ情報抽出
 
 ## 使用例

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "concrnt2SNS",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,6 @@
         "@atproto/api": "^0.12.29",
         "@concrnt/client": "^0.0.24",
         "@concrnt/worldlib": "^0.1.4",
-        "axios": "^1.7.7",
         "cheerio": "^1.1.2",
         "mp4box": "^0.5.4",
         "nostr-tools": "^2.11.0",
@@ -682,28 +681,11 @@
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/await-lock": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -847,18 +829,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -885,15 +855,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -1052,40 +1013,6 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1187,27 +1114,6 @@
       "license": "ISC",
       "dependencies": {
         "libsodium-sumo": "^0.7.15"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -1353,12 +1259,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/readonly-date": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "concrnt2SNS",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@atproto/api": "^0.12.29",
     "@concrnt/client": "^0.0.24",
     "@concrnt/worldlib": "^0.1.4",
-    "axios": "^1.7.7",
     "cheerio": "^1.1.2",
     "mp4box": "^0.5.4",
     "nostr-tools": "^2.11.0",

--- a/src/Clients/AtProtocol.js
+++ b/src/Clients/AtProtocol.js
@@ -284,19 +284,23 @@ class AtProtocol {
                     body: data
                 })
 
-                if (!res.ok) {
-                    let responseData
+                const responseText = await res.text()
+                let responseData = responseText
+                if (responseText) {
                     try {
-                        responseData = await res.json()
+                        responseData = JSON.parse(responseText)
                     } catch (e) {
-                        responseData = await res.text()
+                        responseData = responseText
                     }
+                }
+
+                if (!res.ok) {
                     const error = new Error(`Request failed with status ${res.status}`)
                     error.response = { status: res.status, data: responseData }
                     throw error
                 }
 
-                return await res.json()
+                return responseData
             } catch (error) {
                 const responseStatus = error.response?.status
                 const responseData = error.response?.data

--- a/src/Clients/AtProtocol.js
+++ b/src/Clients/AtProtocol.js
@@ -1,6 +1,5 @@
 import { BskyAgent, RichText } from '@atproto/api'
 import OgImage from '../Utils/OgImage.js'
-import axios from 'axios'
 
 const MAX_MEDIA_UPLOAD_RETRYS = 3
 // コンカレのラベルとBSのラベルの対応
@@ -227,14 +226,14 @@ class AtProtocol {
 
         const token = authResult.token
 
-        const res = await axios.get('https://video.bsky.app/xrpc/app.bsky.video.getUploadLimits', {
-            'headers': {
+        const res = await fetch('https://video.bsky.app/xrpc/app.bsky.video.getUploadLimits', {
+            headers: {
                 'Accept': 'application/json',
                 'Authorization': `Bearer ${token}`
             }
         })
 
-        return res.data
+        return await res.json()
     }*/
 
     async getVideoJobStatus(jobId) {
@@ -249,14 +248,16 @@ class AtProtocol {
         const token = authResult.token
 
         try {
-            const res = await axios.get(`https://video.bsky.app/xrpc/app.bsky.video.getJobStatus?jobId=${jobId}`, {
-                'headers': {
+            const res = await fetch(`https://video.bsky.app/xrpc/app.bsky.video.getJobStatus?jobId=${jobId}`, {
+                headers: {
                     'Accept': 'application/json',
                     'Authorization': `Bearer ${token}`
                 }
             })
 
-            return res.data
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`)
+
+            return await res.json()
         } catch (error) {
             console.log(error)
             return { jobId: "" }
@@ -272,21 +273,30 @@ class AtProtocol {
             const authResult = await this.getServiceAuth(this.aud, 'com.atproto.repo.uploadBlob')
             const token = authResult.token
 
-            let config = {
-                method: 'post',
-                maxBodyLength: Infinity,
-                url: `https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${did}&name=${name}`,
-                headers: {
-                    'Content-Type': 'video/mp4',
-                    'Accept': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                },
-                data: data
-            }
-
             try {
-                const res = await axios(config)
-                return res.data
+                const res = await fetch(`https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${did}&name=${name}`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'video/mp4',
+                        'Accept': 'application/json',
+                        'Authorization': `Bearer ${token}`
+                    },
+                    body: data
+                })
+
+                if (!res.ok) {
+                    let responseData
+                    try {
+                        responseData = await res.json()
+                    } catch (e) {
+                        responseData = await res.text()
+                    }
+                    const error = new Error(`Request failed with status ${res.status}`)
+                    error.response = { status: res.status, data: responseData }
+                    throw error
+                }
+
+                return await res.json()
             } catch (error) {
                 const responseStatus = error.response?.status
                 const responseData = error.response?.data

--- a/src/Clients/Threads.js
+++ b/src/Clients/Threads.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { readFile, writeFile } from 'fs/promises';
 
 class Threads {
@@ -51,7 +50,7 @@ class Threads {
 
     static async getTokenInfo(accessToken) {
         try {
-            const response = await axios.get(
+            const res = await fetch(
                 `https://graph.threads.net/${Threads.graphApiVersion}/debug_token?access_token=${accessToken}&input_token=${accessToken}`,
                 {
                     headers: {
@@ -59,8 +58,10 @@ class Threads {
                     },
                 }
             );
-            console.log('アクセストークン情報:', response.data.data);
-            return response.data.data;
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+            const data = await res.json();
+            console.log('アクセストークン情報:', data.data);
+            return data.data;
         } catch (error) {
             console.error('アクセストークンの情報取得に失敗しました:', true, error.message);
             return { is_valid: false };
@@ -69,7 +70,7 @@ class Threads {
 
     static async getRefreshToken(accessToken) {
         try {
-            const response = await axios.get(
+            const res = await fetch(
                 `https://graph.threads.net/${Threads.graphApiVersion}/refresh_access_token?grant_type=th_refresh_token&access_token=${accessToken}`,
                 {
                     headers: {
@@ -77,10 +78,12 @@ class Threads {
                     },
                 }
             );
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+            const data = await res.json();
             return {
-                "access_token": response.data.access_token,
-                "token_type": response.data.token_type,
-                "expires_at": Date.now() + (response.data.expires_in * 1000)
+                "access_token": data.access_token,
+                "token_type": data.token_type,
+                "expires_at": Date.now() + (data.expires_in * 1000)
             };
         } catch (error) {
             console.error('アクセストークンの更新に失敗しました:', true, error.message);
@@ -207,12 +210,20 @@ class Threads {
 
     async createContainer(data) {
         try {
-            const response = await axios.post(
+            const res = await fetch(
                 this.CREATE_CONTAINER_URL,
-                data,
-                this.HEADERS
+                {
+                    method: 'POST',
+                    headers: {
+                        ...this.HEADERS.headers,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(data)
+                }
             );
-            return response.data.id;
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+            const responseData = await res.json();
+            return responseData.id;
         } catch (error) {
             console.error('コンテナの作成に失敗しました:', error.message);
         }
@@ -220,11 +231,13 @@ class Threads {
 
     async getContainerStatus(id) {
         try {
-            const response = await axios.get(
+            const res = await fetch(
                 `${this.CONTAINER_STATUS_URL}${id}?fields=status`,
                 this.HEADERS
             );
-            return response.data.status === 'PUBLISHED' || response.data.status === 'FINISHED'
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+            const responseData = await res.json();
+            return responseData.status === 'PUBLISHED' || responseData.status === 'FINISHED'
         } catch (error) {
             console.error('コンテナのステータス取得に失敗しました:', error.message);
         }
@@ -232,13 +245,20 @@ class Threads {
 
     async publishContainer(containerId) {
         try {
-            await axios.post(
+            const res = await fetch(
                 this.PUBLISH_URL,
                 {
-                    creation_id: containerId,
-                },
-                this.HEADERS
+                    method: 'POST',
+                    headers: {
+                        ...this.HEADERS.headers,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        creation_id: containerId,
+                    })
+                }
             );
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
         } catch (error) {
             console.error('コンテナの公開に失敗しました:', error.message);
         }

--- a/src/Clients/Twitter.js
+++ b/src/Clients/Twitter.js
@@ -1,5 +1,4 @@
 import { TwitterApi } from 'twitter-api-v2'
-import axios from 'axios'
 
 const MAX_MEDIA_UPLOAD_RETRYS = 3
 // コンカレのラベルとTwitterのラベルの対応
@@ -120,24 +119,35 @@ class Twitter {
           }
         }`
 
-        let config = {
-            method: 'post',
-            url: 'https://api.buffer.com',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${this.bufferToken}`
-            },
-            data: { query: query }
-        }
-
         try {
-            const response = await axios(config)
+            const res = await fetch('https://api.buffer.com', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${this.bufferToken}`
+                },
+                body: JSON.stringify({ query: query })
+            })
+
+            let responseData
+            try {
+                responseData = await res.json()
+            } catch (e) {
+                responseData = await res.text()
+            }
+
+            if (!res.ok) {
+                const error = new Error(`Request failed with status ${res.status}`)
+                error.response = { status: res.status, data: responseData }
+                throw error
+            }
+
             // Buffer GraphQL API returns 200 OK even for errors, need to check if response.data.errors exists
-            if (response.data && response.data.errors) {
-                console.error(`Failed to tweet via Buffer. GraphQL Errors:`, response.data.errors)
-            } else if (response.data && response.data.data && response.data.data.createPost && response.data.data.createPost.message) {
+            if (responseData && responseData.errors) {
+                console.error(`Failed to tweet via Buffer. GraphQL Errors:`, responseData.errors)
+            } else if (responseData && responseData.data && responseData.data.createPost && responseData.data.createPost.message) {
                 // ... on MutationError returns a message inside the data
-                console.error(`Failed to tweet via Buffer. MutationError:`, response.data.data.createPost.message)
+                console.error(`Failed to tweet via Buffer. MutationError:`, responseData.data.createPost.message)
             }
         } catch (error) {
             const responseStatus = error.response ? error.response.status : error.message
@@ -151,17 +161,26 @@ class Twitter {
             "value1": text,
             "value2": imageURL
         }
-        let config = {
-            method: 'post',
-            url: url,
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            data: data
-        }
-
         try {
-            await axios(config)
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            })
+
+            if (!res.ok) {
+                let responseData
+                try {
+                    responseData = await res.json()
+                } catch (e) {
+                    responseData = await res.text()
+                }
+                const error = new Error(`Request failed with status ${res.status}`)
+                error.response = { status: res.status, data: responseData }
+                throw error
+            }
         } catch (error) {
             const responseStatus = error.response ? error.response.status : error.message
             console.error(`Failed to tweet on WebHook. status: ${responseStatus}`, error.response?.data || "")

--- a/src/Clients/Twitter.js
+++ b/src/Clients/Twitter.js
@@ -129,11 +129,14 @@ class Twitter {
                 body: JSON.stringify({ query: query })
             })
 
-            let responseData
-            try {
-                responseData = await res.json()
-            } catch (e) {
-                responseData = await res.text()
+            const responseText = await res.text()
+            let responseData = responseText
+            if (responseText) {
+                try {
+                    responseData = JSON.parse(responseText)
+                } catch (e) {
+                    responseData = responseText
+                }
             }
 
             if (!res.ok) {
@@ -171,11 +174,14 @@ class Twitter {
             })
 
             if (!res.ok) {
-                let responseData
-                try {
-                    responseData = await res.json()
-                } catch (e) {
-                    responseData = await res.text()
+                const responseText = await res.text()
+                let responseData = responseText
+                if (responseText) {
+                    try {
+                        responseData = JSON.parse(responseText)
+                    } catch (e) {
+                        responseData = responseText
+                    }
                 }
                 const error = new Error(`Request failed with status ${res.status}`)
                 error.response = { status: res.status, data: responseData }

--- a/src/Utils/MetaTagExtractor.js
+++ b/src/Utils/MetaTagExtractor.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
 
 /**
@@ -15,22 +14,32 @@ class MetaTagExtractor {
   /**
    * 指定されたURLからメタ情報を抽出
    * @param {string} url - 対象のURL
-   * @param {object} options - axiosのオプション (timeout, headers など)
+   * @param {object} options - fetchのオプション (timeout, headers など)
    * @returns {Promise<object>} メタ情報オブジェクト
    */
   async extractMeta(url, options = {}) {
+    let timeoutId;
     try {
+      const timeout = options.timeout || 10000;
+      const controller = new AbortController();
+      timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      // fetch では maxRedirects は redirect: 'follow' (デフォルト) で処理され、細かい制限は標準では困難なため削除
+      const { timeout: _timeout, maxRedirects: _maxRedirects, ...fetchOptions } = options;
+
       const defaultOptions = {
-        timeout: 10000,
+        signal: controller.signal,
         headers: {
           'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
         },
-        maxRedirects: 5,
-        ...options
+        ...fetchOptions
       };
 
-      const response = await axios.get(url, defaultOptions);
-      const html = response.data;
+      const response = await fetch(url, defaultOptions);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const html = await response.text();
       const $ = cheerio.load(html);
 
       // 基本情報の抽出
@@ -58,6 +67,8 @@ class MetaTagExtractor {
     } catch (error) {
       console.error(`Error extracting meta from ${url}:`, error.message);
       throw error;
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
     }
   }
 

--- a/src/Utils/MetaTagExtractor.js
+++ b/src/Utils/MetaTagExtractor.js
@@ -20,7 +20,7 @@ class MetaTagExtractor {
   async extractMeta(url, options = {}) {
     let timeoutId;
     try {
-      const timeout = options.timeout || 10000;
+      const timeout = options.timeout ?? 10000;
       const controller = new AbortController();
       timeoutId = setTimeout(() => controller.abort(), timeout);
 

--- a/src/Utils/OgImage.js
+++ b/src/Utils/OgImage.js
@@ -1,5 +1,4 @@
 import sharp from "sharp";
-import axios from 'axios';
 import MetaTagExtractor from './MetaTagExtractor.js';
 
 const GOOGLE_FAVICON_URL = "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&size=256&url="
@@ -52,7 +51,9 @@ class OgImage {
     if (ccClient && "world.concrnt.hyperproxy.summary" in ccClient?.domainServices) {
       const summaryUrl = `https://${ccClient.host}${ccClient.domainServices['world.concrnt.hyperproxy.summary'].path}?url=${encodeURIComponent(url)}`
       try {
-        const { data } = await axios.get(summaryUrl)
+        const res = await fetch(summaryUrl)
+        if (!res.ok) throw new Error(`Request failed with status ${res.status}`)
+        const data = await res.json()
         if (data.thumbnail) { // thumbnailがあれば使う
           ogImageUrl = data.thumbnail
         } else if (data.icon.endsWith(".ico")) {  // faviconがico形式の場合は、GoogleのFavicon取得APIを使う


### PR DESCRIPTION
This PR replaces the `axios` library with the native Node.js `fetch` API across the entire project.

**Changes:**
- Replaced `axios.get`, `axios.post`, and `axios(...)` calls with `fetch` equivalents.
- Handled error states by checking `response.ok` and constructing error objects (`error.response`) to maintain compatibility with existing error logging mechanisms.
- Updated `MetaTagExtractor` to replicate Axios' timeout feature using `AbortController` and `setTimeout`.
- Uninstalled `axios` via `npm uninstall axios`, updating `package.json` and `package-lock.json`.
- Updated documentation files to change references of `axios` to `fetch API`.

---
*PR created automatically by Jules for task [2523576098971975281](https://jules.google.com/task/2523576098971975281) started by @ryotn*